### PR TITLE
Kernel Configuration: add SELinux LSM support

### DIFF
--- a/sources/config-cachyos-bore/config
+++ b/sources/config-cachyos-bore/config
@@ -10561,7 +10561,7 @@ CONFIG_INTEGRITY_AUDIT=y
 # CONFIG_DEFAULT_SECURITY_TOMOYO is not set
 # CONFIG_DEFAULT_SECURITY_APPARMOR is not set
 CONFIG_DEFAULT_SECURITY_DAC=y
-CONFIG_LSM="landlock,lockdown,yama,integrity,bpf"
+CONFIG_LSM="landlock,lockdown,yama,integrity,bpf,selinux"
 
 #
 # Kernel hardening options


### PR DESCRIPTION
Should be added to make SELinux work out of the box on the next COPR releases, your thoughts? Thank you very much for the port.