### PR TITLE
Enable SCHED_DEBUG and DEBUG_INFO_DWARF5 flags to fix sched_ext support in the stable kernel.

### DIFF
--- a/sources/kernel-cachyos-bore/kernel-cachyos-lto.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos-lto.spec
@@ -263,8 +263,10 @@ scripts/config -e BPF_SYSCALL
 scripts/config -e DEBUG_INFO
 scripts/config -e DEBUG_INFO_BTF
 scripts/config -e DEBUG_INFO_BTF_MODULES
+scripts/config -e DEBUG_INFO_DWARF5
 scripts/config -e FTRACE
 scripts/config -e PAHOLE_HAS_SPLIT_BTF
+scripts/config -e SCHED_DEBUG
 
 # Setting tick rate
 scripts/config -d HZ_300
@@ -286,13 +288,11 @@ scripts/config --set-str DEFAULT_NET_SCH fq
 
 # Disable DEBUG
 scripts/config -d DEBUG_INFO_DWARF4
-scripts/config -d DEBUG_INFO_DWARF5
 scripts/config -d SLUB_DEBUG
 scripts/config -d PM_DEBUG
 scripts/config -d PM_ADVANCED_DEBUG
 scripts/config -d PM_SLEEP_DEBUG
 scripts/config -d ACPI_DEBUG
-scripts/config -d SCHED_DEBUG
 scripts/config -d LATENCYTOP
 scripts/config -d DEBUG_PREEMPT
 

--- a/sources/kernel-cachyos-bore/kernel-cachyos.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos.spec
@@ -263,8 +263,10 @@ scripts/config -e BPF_SYSCALL
 scripts/config -e DEBUG_INFO
 scripts/config -e DEBUG_INFO_BTF
 scripts/config -e DEBUG_INFO_BTF_MODULES
+scripts/config -e DEBUG_INFO_DWARF5
 scripts/config -e FTRACE
 scripts/config -e PAHOLE_HAS_SPLIT_BTF
+scripts/config -e SCHED_DEBUG
 
 # Setting tick rate
 scripts/config -d HZ_300
@@ -286,13 +288,11 @@ scripts/config --set-str DEFAULT_NET_SCH fq
 
 # Disable DEBUG
 scripts/config -d DEBUG_INFO_DWARF4
-scripts/config -d DEBUG_INFO_DWARF5
 scripts/config -d SLUB_DEBUG
 scripts/config -d PM_DEBUG
 scripts/config -d PM_ADVANCED_DEBUG
 scripts/config -d PM_SLEEP_DEBUG
 scripts/config -d ACPI_DEBUG
-scripts/config -d SCHED_DEBUG
 scripts/config -d LATENCYTOP
 scripts/config -d DEBUG_PREEMPT
 


### PR DESCRIPTION
These flags need to be enabled for other debug config flags to be enabled, otherwise they will get disabled at runtime.

All the flags need to be enabled for sched_ext to work.