### PR TITLE
Add prebuilt nvidia-open kernel modules for CachyOS kernels.

### DIFF
--- a/sources/kernel-cachyos-bore/kernel-cachyos-lto.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos-lto.spec
@@ -407,8 +407,8 @@ make %{?_smp_mflags} INSTALL_HDR_PATH=%{buildroot}/usr headers_install
 
 # Le nvidia-open
 cd %{_sourcedir}/%{_nv_open_pkg}
-install -dm755 "%{buildroot}/lib/modules/%{kverstr}/extra"
-install -m644 kernel-open/*.ko "%{buildroot}/lib/modules/%{kverstr}/extra"
+install -dm755 "%{buildroot}/lib/modules/%{kverstr}/extra/nvidia"
+install -m644 kernel-open/*.ko "%{buildroot}/lib/modules/%{kverstr}/extra/nvidia"
 install -Dt "%{buildroot}/usr/share/licenses/nvidia-open" -m644 COPYING
 find "%{buildroot}" -name '*.ko' -exec zstd --rm -10 {} +
 
@@ -714,7 +714,7 @@ fi
 %exclude /lib/modules/%{kverstr}/source
 
 %files nvidia-open
-%dir /lib/modules/%{kverstr}/extra
+%dir /lib/modules/%{kverstr}/extra/nvidia
 /usr/share/licenses/nvidia-open/COPYING
 
 %files headers

--- a/sources/kernel-cachyos-bore/kernel-cachyos-lto.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos-lto.spec
@@ -365,7 +365,7 @@ scripts/config -e HAVE_GCC_PLUGINS
 scripts/config -u DEFAULT_HOSTNAME
 
 # Enable SELinux (https://github.com/sirlucjan/copr-linux-cachyos/pull/1)
-scripts/config --set-str CONFIG_LSM â€œlockdown,yama,integrity,selinux,bpf,landlockâ€
+scripts/config --set-str CONFIG_LSM “lockdown,yama,integrity,selinux,bpf,landlock”
 
 # Set kernel version string as build salt
 scripts/config --set-str BUILD_SALT "%{kverstr}"

--- a/sources/kernel-cachyos-bore/kernel-cachyos-lto.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos-lto.spec
@@ -171,11 +171,11 @@ This package provides kernel modules for the core %{?flavor:%{flavor}} kernel pa
 %package nvidia-open
 Summary: Prebuilt nvidia-open kernel modules to match the core kernel
 Group: System Environment/Kernel
-Provides: kmod-nvidia-%{kverstr}
+Provides: nvidia-kmod = %{_nv_ver}
 Obsoletes: kmod-nvidia-%{kverstr}
 Obsoletes: akmod-nvidia
 Requires: kernel-cachyos-core-lto = %{rpmver}
-Requires: xorg-x11-drv-nvidia
+Requires: xorg-x11-drv-nvidia = %{_nv_ver}
 %description nvidia-open
 This package provides prebuilt nvidia-open kernel modules for the core %{?flavor:%{flavor}} kernel package.
 


### PR DESCRIPTION
The motivation behind this PR is that nvidia's open gpu kernel modules fail to build correctly on clang LTO built kernels. I have taken inspiration from upstream CachyOS's PKGBUILD and ported over to the spec file.

I have tested this locally and can confirm that the open kernel modules work and communicates correctly with the userspace drivers.

One major issue right now is that there are two versions of nvidia userspace drivers provided by Fedora, one by RPMFusion and one by Negativo17. The driver package scheme and naming differs between these two and I am unsure on how to resolve the package dependencies. At the moment, I have set RPMFusion's nvidia userspace driver as a dependency so Negativo17 drivers unfortunately can't use it at the moment (See L178). I hope that this gets resolved in this PR so all users can happily use the LTO built kernels and nvidia's open kernel modules.