### PR TITLE
Add cachyos-fkm-config (Enable this Copr Support to be read by [fedora-kernel-manager)](https://github.com/CosmicFusion/fedora-kernel-manager))

### DIFF
--- a/sources/cachyos-fkm-config/99-fkm.kernel.cachyos.init.rules
+++ b/sources/cachyos-fkm-config/99-fkm.kernel.cachyos.init.rules
@@ -1,0 +1,6 @@
+/* Allow passwordless auth for fkm.kernel.cachyos.init
+polkit.addRule(function(action, subject) {
+    if (action.id == "fkm.kernel.cachyos.init") {
+        return polkit.Result.YES;
+    }
+});

--- a/sources/cachyos-fkm-config/cachyos-fkm-config.spec
+++ b/sources/cachyos-fkm-config/cachyos-fkm-config.spec
@@ -1,0 +1,37 @@
+%define _disable_source_fetch 0
+
+Name:          cachyos-fkm-config
+Version:       1.0
+Release:       1%{?dist}
+License:       GPLv2
+Group:         System Environment/Libraries
+Summary:       Config files to enable coprs/bieszczaders/kernel-cachyos in fedora-kernel-manager.
+
+
+URL:            https://github.com/sirlucjan/copr-linux-cachyos
+Source0:        https://raw.githubusercontent.com/sirlucjan/copr-linux-cachyos/master/sources/cachyos-fkm-config/kernel-cachyos.json
+Source1:        https://raw.githubusercontent.com/sirlucjan/copr-linux-cachyos/master/sources/cachyos-fkm-config/kernel-cachyos-init.sh
+Source2:        https://raw.githubusercontent.com/sirlucjan/copr-linux-cachyos/master/sources/cachyos-fkm-config/fkm.kernel.cachyos.init.policy
+Source3:        https://raw.githubusercontent.com/sirlucjan/copr-linux-cachyos/master/sources/cachyos-fkm-config/99-fkm.kernel.cachyos.init.rules
+
+Requires:   fedora-kernel-manager
+
+%description
+Config files to enable coprs/bieszczaders/kernel-cachyos in fedora-kernel-manager.
+
+%install
+mkdir -p $RPM_BUILD_ROOT/%{_prefix}/lib/fedora-kernel-manager/kernel_branches/
+mkdir -p $RPM_BUILD_ROOT/%{_prefix}/lib/fedora-kernel-manager/scripts
+mkdir -p $RPM_BUILD_ROOT/%{_datadir}/polkit-1/actions/
+mkdir -p $RPM_BUILD_ROOT/%{_datadir}/polkit-1/rules.d/
+cp %{SOURCE0} $RPM_BUILD_ROOT/%{_prefix}/lib/fedora-kernel-manager/kernel_branches/
+cp %{SOURCE1} $RPM_BUILD_ROOT/%{_prefix}/lib/fedora-kernel-manager/scripts/
+cp %{SOURCE2} $RPM_BUILD_ROOT/%{_datadir}/polkit-1/actions/
+cp %{SOURCE3} $RPM_BUILD_ROOT/%{_datadir}/polkit-1/rules.d/
+chmod 755 $RPM_BUILD_ROOT/%{_prefix}/lib/fedora-kernel-manager/scripts/kernel-cachyos-init.sh
+
+%files
+%{_prefix}/lib/fedora-kernel-manager/kernel_branches/kernel-cachyos.json
+%{_prefix}/lib/fedora-kernel-manager/scripts/kernel-cachyos-init.sh
+%{_datadir}/polkit-1/actions/fkm.kernel.cachyos.init.policy
+%{_datadir}/polkit-1/rules.d/99-fkm.kernel.cachyos.init.rules

--- a/sources/cachyos-fkm-config/db_kernel_cachy.json
+++ b/sources/cachyos-fkm-config/db_kernel_cachy.json
@@ -1,0 +1,41 @@
+{
+  "latest_kernel_version_deter_pkg": "kernel-cachyos",
+  "kernels": [
+    {
+      "name": "CachyOS Default Kernel",
+      "main_package": "kernel-cachyos",
+      "packages": "kernel-cachyos kernel-cachyos-devel-matched",
+      "min_x86_march": "3"
+    },
+    {
+      "name": "CachyOS LTS Kernel",
+      "main_package": "kernel-cachyos-lts",
+      "packages": "kernel-cachyos-lts kernel-cachyos-lts-devel-matched",
+      "min_x86_march": "2"
+    },
+    {
+      "name": "Sched EXT SCX",
+      "main_package": "sched-ext-scx",
+      "packages": "sched-ext-scx",
+      "min_x86_march": "1"
+    },
+    {
+      "name": "UKSMD Daemon",
+      "main_package": "uksmd",
+      "packages": "uksmd",
+      "min_x86_march": "1"
+    },
+    {
+      "name": "CachyOS-Settings",
+      "main_package": "cachyos-settings",
+      "packages": "cachyos-settings",
+      "min_x86_march": "1"
+    },
+    {
+      "name": "Ananicy-CPP",
+      "main_package": "ananicy-cpp",
+      "packages": "ananicy-cpp",
+      "min_x86_march": "1"
+    }
+  ]
+}

--- a/sources/cachyos-fkm-config/fkm.kernel.cachyos.init.policy
+++ b/sources/cachyos-fkm-config/fkm.kernel.cachyos.init.policy
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policyconfig PUBLIC
+ "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
+ "http://www.freedesktop.org/software/polkit/policyconfig-1.dtd">
+<policyconfig>
+
+  <action id="fkm.kernel.cachyos.init">
+    <message>Authentication is required to initialize the Cachyos kernel repo</message>
+    <icon_name>com.github.cosmicfusion.fedora-kernel-manager</icon_name>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
+      <allow_active>auth_admin</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.exec.path">/usr/lib/fedora-kernel-manager/scripts/kernel-cachyos-init.sh</annotate>
+    <annotate key="org.freedesktop.policykit.exec.allow_gui">true</annotate>
+  </action>
+
+</policyconfig>

--- a/sources/cachyos-fkm-config/kernel-cachyos-init.sh
+++ b/sources/cachyos-fkm-config/kernel-cachyos-init.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+YUM_CHANGED=false
+KERNEL_CACHYOS_REPO_FILE='/etc/yum.repos.d/_copr:copr.fedorainfracloud.org:bieszczaders:kernel-cachyos.repo'
+KERNEL_CACHYOS_ADDONS_REPO_FILE='/etc/yum.repos.d/_copr:copr.fedorainfracloud.org:bieszczaders:kernel-cachyos-addons.repo'
+
+if [ ! -f $KERNEL_CACHYOS_REPO_FILE ]
+then
+  wget https://copr.fedorainfracloud.org/coprs/bieszczaders/kernel-cachyos/repo/fedora-$(rpm -E %fedora)/bieszczaders-kernel-cachyos-fedora-$(rpm -E %fedora).repo -O $KERNEL_CACHYOS_REPO_FILE
+  YUM_CHANGED=true
+fi
+
+if [ ! -f $KERNEL_CACHYOS_ADDONS_REPO_FILE ]
+then
+  wget https://copr.fedorainfracloud.org/coprs/bieszczaders/kernel-cachyos-addons/repo/fedora-$(rpm -E %fedora)/bieszczaders-kernel-cachyos-addons-fedora-$(rpm -E %fedora).repo -O $KERNEL_CACHYOS_ADDONS_REPO_FILE
+  YUM_CHANGED=true
+fi
+
+if [ YUM_CHANGED == true ]
+then
+     dnf repoquery
+fi

--- a/sources/cachyos-fkm-config/kernel-cachyos.json
+++ b/sources/cachyos-fkm-config/kernel-cachyos.json
@@ -1,0 +1,5 @@
+{
+  "name": "kernel-cachyos",
+  "db_url": "https://raw.githubusercontent.com/sirlucjan/copr-linux-cachyos/master/sources/cachyos-fkm-config/db_kernel_cachy.json",
+  "init_script": "pkexec /usr/lib/fedora-kernel-manager/scripts/kernel-cachyos-init.sh"
+}


### PR DESCRIPTION
A Simple Package that allows your copr repos to be added and listed on  [fedora-kernel-manager)](https://github.com/CosmicFusion/fedora-kernel-manager)

The file db_kernel_cachy.json is downloaded by the app at runtime, and with it you can control what shows up to the user.