### PR TITLE
sched-ext-scx: mark /etc/default/scx as %config(noreplace)

### DIFF
--- a/sources/sched-ext-scx/sched-ext-scx.spec
+++ b/sources/sched-ext-scx/sched-ext-scx.spec
@@ -53,5 +53,5 @@ sched_ext is a Linux kernel feature which enables implementing kernel thread sch
 %files
 %{_bindir}/*
 %{_prefix}/lib/systemd/system/scx.service
-%{_sysconfdir}/default/scx
+%attr(0644,root,root) %ghost %config(noreplace) %{_sysconfdir}/default/scx
 %{_sysconfdir}/systemd/journald@sched-ext.conf


### PR DESCRIPTION
We need to mark `/etc/default/scx` as a config file in the spec file so user set configurations do not get replaced upon every package update.