### PR TITLE
kernel: Use fq_codel instead of fq for DEFAULT_NET_SCH

### DIFF
--- a/sources/kernel-cachyos-bore/kernel-cachyos-lto.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos-lto.spec
@@ -37,7 +37,7 @@ Summary: The Linux Kernel with Cachyos-BORE-EEVDF Patches
 %define _stablekver 8
 Version: %{_basekver}.%{_stablekver}
 
-%define customver 1
+%define customver 2
 %define flaver cb%{customver}
 
 Release:%{flaver}.0%{?ltoflavor:.lto}%{?dist}
@@ -282,12 +282,6 @@ scripts/config -d DEFAULT_CUBIC
 scripts/config -e TCP_CONG_BBR
 scripts/config -e DEFAULT_BBR
 scripts/config --set-str DEFAULT_TCP_CONG bbr
-# Switch into FQ - bbr3 doesn't work properly with FQ_CODEL
-scripts/config -m NET_SCH_FQ_CODEL
-scripts/config -e NET_SCH_FQ
-scripts/config -d DEFAULT_FQ_CODEL
-scripts/config -e DEFAULT_FQ
-scripts/config --set-str DEFAULT_NET_SCH fq
 
 # Disable DEBUG
 scripts/config -d SLUB_DEBUG

--- a/sources/kernel-cachyos-bore/kernel-cachyos-lts-lto.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos-lts-lto.spec
@@ -33,7 +33,7 @@ Summary: The Linux Kernel with Cachyos-LTS Patches built with Clang LTO
 %define _stablekver 37
 Version: %{_basekver}.%{_stablekver}
 
-%define customver 1
+%define customver 2
 %define flaver clts%{customver}
 
 Release:%{flaver}.0.lto%{?dist}
@@ -239,12 +239,6 @@ scripts/config -d DEFAULT_CUBIC
 scripts/config -e TCP_CONG_BBR
 scripts/config -e DEFAULT_BBR
 scripts/config --set-str DEFAULT_TCP_CONG bbr
-# Switch into FQ - bbr3 doesn't work properly with FQ_CODEL
-scripts/config -m NET_SCH_FQ_CODEL
-scripts/config -e NET_SCH_FQ
-scripts/config -d DEFAULT_FQ_CODEL
-scripts/config -e DEFAULT_FQ
-scripts/config --set-str DEFAULT_NET_SCH fq
 
 # Disable DEBUG
 scripts/config -d DEBUG_INFO

--- a/sources/kernel-cachyos-bore/kernel-cachyos-lts.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos-lts.spec
@@ -33,7 +33,7 @@ Summary: The Linux Kernel with Cachyos-LTS Patches
 %define _stablekver 37
 Version: %{_basekver}.%{_stablekver}
 
-%define customver 1
+%define customver 2
 %define flaver clts%{customver}
 
 Release:%{flaver}.0%{?dist}
@@ -239,12 +239,6 @@ scripts/config -d DEFAULT_CUBIC
 scripts/config -e TCP_CONG_BBR
 scripts/config -e DEFAULT_BBR
 scripts/config --set-str DEFAULT_TCP_CONG bbr
-# Switch into FQ - bbr3 doesn't work properly with FQ_CODEL
-scripts/config -m NET_SCH_FQ_CODEL
-scripts/config -e NET_SCH_FQ
-scripts/config -d DEFAULT_FQ_CODEL
-scripts/config -e DEFAULT_FQ
-scripts/config --set-str DEFAULT_NET_SCH fq
 
 # Disable DEBUG
 scripts/config -d DEBUG_INFO

--- a/sources/kernel-cachyos-bore/kernel-cachyos.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos.spec
@@ -37,7 +37,7 @@ Summary: The Linux Kernel with Cachyos-BORE-EEVDF Patches
 %define _stablekver 8
 Version: %{_basekver}.%{_stablekver}
 
-%define customver 1
+%define customver 2
 %define flaver cb%{customver}
 
 Release:%{flaver}.0%{?ltoflavor:.lto}%{?dist}
@@ -282,12 +282,6 @@ scripts/config -d DEFAULT_CUBIC
 scripts/config -e TCP_CONG_BBR
 scripts/config -e DEFAULT_BBR
 scripts/config --set-str DEFAULT_TCP_CONG bbr
-# Switch into FQ - bbr3 doesn't work properly with FQ_CODEL
-scripts/config -m NET_SCH_FQ_CODEL
-scripts/config -e NET_SCH_FQ
-scripts/config -d DEFAULT_FQ_CODEL
-scripts/config -e DEFAULT_FQ
-scripts/config --set-str DEFAULT_NET_SCH fq
 
 # Disable DEBUG
 scripts/config -d SLUB_DEBUG


### PR DESCRIPTION
The PKGBUILD used by CachyOS has long since defaulted to fq_codel instead of fq. This PR syncs it to be more inline with the PKGBUILD. 