### PR TITLE
kernel: Remove double quotes from LSM

### DIFF
--- a/sources/kernel-cachyos-bore/kernel-cachyos-lto.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos-lto.spec
@@ -37,7 +37,7 @@ Summary: The Linux Kernel with Cachyos-BORE-EEVDF Patches
 %define _stablekver 8
 Version: %{_basekver}.%{_stablekver}
 
-%define customver 1
+%define customver 3
 %define flaver cb%{customver}
 
 Release:%{flaver}.0%{?ltoflavor:.lto}%{?dist}
@@ -346,7 +346,7 @@ scripts/config -e HAVE_GCC_PLUGINS
 scripts/config -u DEFAULT_HOSTNAME
 
 # Enable SELinux (https://github.com/sirlucjan/copr-linux-cachyos/pull/1)
-scripts/config --set-str CONFIG_LSM “lockdown,yama,integrity,selinux,bpf,landlock”
+scripts/config --set-str CONFIG_LSM lockdown,yama,integrity,selinux,bpf,landlock
 
 # Set kernel version string as build salt
 scripts/config --set-str BUILD_SALT "%{kverstr}"

--- a/sources/kernel-cachyos-bore/kernel-cachyos-lts-lto.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos-lts-lto.spec
@@ -33,7 +33,7 @@ Summary: The Linux Kernel with Cachyos-LTS Patches built with Clang LTO
 %define _stablekver 37
 Version: %{_basekver}.%{_stablekver}
 
-%define customver 1
+%define customver 3
 %define flaver clts%{customver}
 
 Release:%{flaver}.0.lto%{?dist}
@@ -314,7 +314,7 @@ scripts/config -e HAVE_GCC_PLUGINS
 scripts/config -u DEFAULT_HOSTNAME
 
 # Enable SELinux (https://github.com/sirlucjan/copr-linux-cachyos/pull/1)
-scripts/config --set-str CONFIG_LSM “lockdown,yama,integrity,selinux,bpf,landlock”
+scripts/config --set-str CONFIG_LSM lockdown,yama,integrity,selinux,bpf,landlock
 
 # Set kernel version string as build salt
 scripts/config --set-str BUILD_SALT "%{kverstr}"

--- a/sources/kernel-cachyos-bore/kernel-cachyos-lts.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos-lts.spec
@@ -33,7 +33,7 @@ Summary: The Linux Kernel with Cachyos-LTS Patches
 %define _stablekver 37
 Version: %{_basekver}.%{_stablekver}
 
-%define customver 1
+%define customver 2
 %define flaver clts%{customver}
 
 Release:%{flaver}.0%{?dist}
@@ -314,7 +314,7 @@ scripts/config -e HAVE_GCC_PLUGINS
 scripts/config -u DEFAULT_HOSTNAME
 
 # Enable SELinux (https://github.com/sirlucjan/copr-linux-cachyos/pull/1)
-scripts/config --set-str CONFIG_LSM “lockdown,yama,integrity,selinux,bpf,landlock”
+scripts/config --set-str CONFIG_LSM lockdown,yama,integrity,selinux,bpf,landlock
 
 # Set kernel version string as build salt
 scripts/config --set-str BUILD_SALT "%{kverstr}"

--- a/sources/kernel-cachyos-bore/kernel-cachyos-lts.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos-lts.spec
@@ -33,7 +33,7 @@ Summary: The Linux Kernel with Cachyos-LTS Patches
 %define _stablekver 37
 Version: %{_basekver}.%{_stablekver}
 
-%define customver 2
+%define customver 3
 %define flaver clts%{customver}
 
 Release:%{flaver}.0%{?dist}

--- a/sources/kernel-cachyos-bore/kernel-cachyos.spec
+++ b/sources/kernel-cachyos-bore/kernel-cachyos.spec
@@ -37,7 +37,7 @@ Summary: The Linux Kernel with Cachyos-BORE-EEVDF Patches
 %define _stablekver 8
 Version: %{_basekver}.%{_stablekver}
 
-%define customver 1
+%define customver 3
 %define flaver cb%{customver}
 
 Release:%{flaver}.0%{?ltoflavor:.lto}%{?dist}
@@ -346,7 +346,7 @@ scripts/config -e HAVE_GCC_PLUGINS
 scripts/config -u DEFAULT_HOSTNAME
 
 # Enable SELinux (https://github.com/sirlucjan/copr-linux-cachyos/pull/1)
-scripts/config --set-str CONFIG_LSM “lockdown,yama,integrity,selinux,bpf,landlock”
+scripts/config --set-str CONFIG_LSM lockdown,yama,integrity,selinux,bpf,landlock
 
 # Set kernel version string as build salt
 scripts/config --set-str BUILD_SALT "%{kverstr}"


### PR DESCRIPTION
I am pretty sure that the double quotes from that line is using a special character because it doesn't get detected as "double quotes" in my text editor.

```bash
zcat /proc/config.gz | grep LSM

CONFIG_LSM="“lockdown,yama,integrity,selinux,bpf,landlock”"
```

Removing these quotes seem to fix it and applies correctly too.

Before PR:
```
Jul 09 00:36:28 varvalian kernel: LSM: initializing lsm=capability,yama,selinux,bpf
Jul 09 00:36:28 varvalian kernel: Yama: becoming mindful.
Jul 09 00:36:28 varvalian kernel: SELinux:  Initializing.
Jul 09 00:36:28 varvalian kernel: LSM support for eBPF active
```

After PR:
```
Jul 09 11:56:31 varvalian kernel: LSM: initializing lsm=capability,lockdown,yama,selinux,bpf,landlock
Jul 09 11:56:31 varvalian kernel: Yama: becoming mindful.
Jul 09 11:56:31 varvalian kernel: SELinux:  Initializing.
Jul 09 11:56:31 varvalian kernel: LSM support for eBPF active
Jul 09 11:56:31 varvalian kernel: landlock: Up and running.
```